### PR TITLE
Logging Fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,6 @@ scalaVersion := "2.11.12"
 
 val sparkVersion = "2.1.1"
 
-val log4jVersion = "2.11.0"
-
 // ------------------------------
 // DEPENDENCIES AND RESOLVERS
 
@@ -25,7 +23,6 @@ libraryDependencies ++= providedDependencies.map(_ % "provided")
 
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scalaz" %% "scalaz-core" % "7.2.5",
   "org.scalacheck" %% "scalacheck" % "1.12.5" % "test",

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,15 @@
+# Publishing the Project to Sonatype
+
+`sbt publishSigned`
+
+`sbt publishLocalSigned`
+
+## External References
+
+- [OSSRH Guide](https://central.sonatype.org/pages/ossrh-guide.html)
+- [Working with PGP Signatures](https://central.sonatype.org/pages/working-with-pgp-signatures.html)
+- [SBT Using Sonatype](https://www.scala-sbt.org/0.13/docs/Using-Sonatype.html)
+
+## Other References
+
+- [Creating a Scala.js Open Source Project](https://www.querki.net/u/jducoeur/scala-notes/#!Creating-a-Scalajs-Open-Source-Project)

--- a/project/gpg.sbt
+++ b/project/gpg.sbt
@@ -1,3 +1,3 @@
 resolvers += Resolver.url("scalasbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/src/main/scala/org/tupol/spark/utils.scala
+++ b/src/main/scala/org/tupol/spark/utils.scala
@@ -128,7 +128,7 @@ package object utils {
    * @return Success if the resource was successfully initialised and the code was successfully ran,
    *         even if the resource was not successfully closed.
    */
-  def tryWithResources[R <: AutoCloseable, T](resource: => R)(code: R => T): Try[T] = {
+  def tryWithCloseable[R <: AutoCloseable, T](resource: => R)(code: R => T): Try[T] = {
     val res = Try(resource)
     val result = res.map(code)
     res.map(r => Try(r.close()))


### PR DESCRIPTION
- excluded the `ch.qos.logback` dependency to fix logging
- log4j is now correctly used and the logging is now manageable and the unit tests are faster
- renamed `utils.tryWithResources` to `utils.tryWithCloseable`
- added minimal documentation about the Sonatype release process
- rolled back the `sbt-pgp` version to 1.1.0